### PR TITLE
pvs-studio fix

### DIFF
--- a/airdcpp/airdcpp/AdcHub.cpp
+++ b/airdcpp/airdcpp/AdcHub.cpp
@@ -877,7 +877,6 @@ void AdcHub::handle(AdcCommand::TCP, AdcCommand& c) noexcept {
 
 void AdcHub::sendHBRI(const string& aIP, const string& aPort, const string& aToken, bool v6) {
 	// Construct the command we are going to send
-	string su;
 	AdcCommand hbriCmd(AdcCommand::CMD_TCP, AdcCommand::TYPE_HUB);
 
 	StringMap dummyMap;

--- a/airdcpp/airdcpp/CryptoManager.cpp
+++ b/airdcpp/airdcpp/CryptoManager.cpp
@@ -487,7 +487,7 @@ void CryptoManager::loadCertificates() noexcept{
 		}
 	}
 
-	loadKeyprint(cert.c_str());
+	loadKeyprint(cert);
 
 	certsLoaded = true;
 }

--- a/airdcpp/airdcpp/DownloadManager.cpp
+++ b/airdcpp/airdcpp/DownloadManager.cpp
@@ -70,7 +70,6 @@ struct DropInfo {
 void DownloadManager::on(TimerManagerListener::Second, uint64_t aTick) noexcept {
 	vector<DropInfo> dropTargets;
 	vector<pair<CID, AdcCommand>> UBNList;
-	StringList targets;
 	BundleList bundleTicks;
 	unordered_map<UserPtr, int64_t, User::Hash> userSpeedMap;
 

--- a/airdcpp/airdcpp/Magnet.cpp
+++ b/airdcpp/airdcpp/Magnet.cpp
@@ -61,7 +61,7 @@ Magnet::Magnet(const string& aLink) {
 		} else if (type.length() == 2 && Util::strnicmp(type.c_str(), "dn", 2) == 0) {
 			fname = param;
 		} else if (type.length() == 2 && Util::strnicmp(type.c_str(), "xl", 2) == 0) {
-			fsize = Util::toInt64(param.c_str());
+			fsize = Util::toInt64(param);
 		}
 	}
 

--- a/airdcpp/airdcpp/UploadManager.cpp
+++ b/airdcpp/airdcpp/UploadManager.cpp
@@ -590,7 +590,6 @@ void UploadManager::onUBN(const AdcCommand& cmd) {
 
 void UploadManager::createBundle(const AdcCommand& cmd) {
 	string bundleToken;
-	string hubIpPort;
 	string token;
 	string name;
 	int64_t size=0, downloaded=0;

--- a/windows/DownloadBaseHandler.h
+++ b/windows/DownloadBaseHandler.h
@@ -132,7 +132,7 @@ public:
 		if(!historyPaths.empty()) {
 			targetMenu_.InsertSeparatorLast(TSTRING(PREVIOUS_FOLDERS));
 			for (const auto& path: historyPaths) {
-				targetMenu_.appendItem(Text::toT(path).c_str(), [=] { onDownload(path, aWholeDir, aIsSizeUnknown, Priority::DEFAULT); });
+				targetMenu_.appendItem(Text::toT(path), [=] { onDownload(path, aWholeDir, aIsSizeUnknown, Priority::DEFAULT); });
 			}
 
 			targetMenu_.appendSeparator();
@@ -145,7 +145,7 @@ private:
 		auto priorityMenu = aMenu.createSubMenu(TSTRING(DOWNLOAD_WITH_PRIORITY));
 
 		auto addItem = [&](const tstring& aTitle, Priority p) -> void {
-			priorityMenu->appendItem(aTitle.c_str(), [=] { onDownload(SETTING(DOWNLOAD_DIRECTORY), aWholeDir, aIsSizeUnknown, p); });
+			priorityMenu->appendItem(aTitle, [=] { onDownload(SETTING(DOWNLOAD_DIRECTORY), aWholeDir, aIsSizeUnknown, p); });
 		};
 
 		addItem(CTSTRING(PAUSED_FORCED), Priority::PAUSED_FORCE);
@@ -179,13 +179,13 @@ private:
 			const auto& targets = dp.second;
 
 			if (targets.size() > 1) {
-				auto vMenu = targetMenu.createSubMenu(Text::toT(groupName).c_str(), true);
+				auto vMenu = targetMenu.createSubMenu(Text::toT(groupName), true);
 				for (const auto& target: targets) {
-					vMenu->appendItem(toDisplayTarget(target, aVolumes).c_str(), [=] { onDownload(target, aWholeDir, aIsSizeUnknown, Priority::DEFAULT); });
+					vMenu->appendItem(toDisplayTarget(target, aVolumes), [=] { onDownload(target, aWholeDir, aIsSizeUnknown, Priority::DEFAULT); });
 				}
 			} else if (!targets.empty()) {
 				auto target = *targets.begin();
-				targetMenu.appendItem(Text::toT(groupName).c_str(), [=] { onDownload(target, aWholeDir, aIsSizeUnknown, Priority::DEFAULT); });
+				targetMenu.appendItem(Text::toT(groupName), [=] { onDownload(target, aWholeDir, aIsSizeUnknown, Priority::DEFAULT); });
 			}
 		}
 	}
@@ -200,7 +200,7 @@ private:
 			if (tthTargets.size()) {
 				targetMenu.InsertSeparatorLast(TSTRING(ADD_AS_SOURCE));
 				for (auto& target : tthTargets) {
-					targetMenu.appendItem(Text::toT(target).c_str(), [=] { onDownload(target, wholeDir, isSizeUnknown, Priority::DEFAULT); });
+					targetMenu.appendItem(Text::toT(target), [=] { onDownload(target, wholeDir, isSizeUnknown, Priority::DEFAULT); });
 				}
 			}
 		}
@@ -226,7 +226,7 @@ private:
 						//use the parent if it's a dir
 						//string displayText = isDir ? Util::getParentDir(target) + " (" + Util::getLastDir(target) + ")" : target;
 						string location = isDir ? Util::getParentDir(target) : target;
-						targetMenu.appendItem(Text::toT(location).c_str(), [=] { onDownload(location, wholeDir, isSizeUnknown, Priority::DEFAULT); });
+						targetMenu.appendItem(Text::toT(location), [=] { onDownload(location, wholeDir, isSizeUnknown, Priority::DEFAULT); });
 					}
 				}
 			};

--- a/windows/MainFrm.cpp
+++ b/windows/MainFrm.cpp
@@ -2026,14 +2026,14 @@ LRESULT MainFrame::onRefreshDropDown(int /*idCtrl*/, LPNMHDR pnmh, BOOL& /*bHand
 	auto l = ShareManager::getInstance()->getGroupedDirectories();
 	for(auto& i: l) {
 		if (i.second.size() > 1) {
-			auto vMenu = dropMenu.createSubMenu(Text::toT(i.first).c_str(), true);
+			auto vMenu = dropMenu.createSubMenu(Text::toT(i.first), true);
 			vMenu->appendItem(CTSTRING(ALL), [=] { ShareManager::getInstance()->refreshVirtualName(i.first); }, OMenu::FLAG_THREADED);
 			vMenu->appendSeparator();
 			for(const auto& s: i.second) {
-				vMenu->appendItem(Text::toT(s).c_str(), [=] { ShareManager::getInstance()->refreshPaths({ s }); }, OMenu::FLAG_THREADED);
+				vMenu->appendItem(Text::toT(s), [=] { ShareManager::getInstance()->refreshPaths({ s }); }, OMenu::FLAG_THREADED);
 			}
 		} else {
-			dropMenu.appendItem(Text::toT(i.first).c_str(), [=] { ShareManager::getInstance()->refreshVirtualName(i.first); }, OMenu::FLAG_THREADED);
+			dropMenu.appendItem(Text::toT(i.first), [=] { ShareManager::getInstance()->refreshVirtualName(i.first); }, OMenu::FLAG_THREADED);
 		}
 	}
 

--- a/windows/Players.cpp
+++ b/windows/Players.cpp
@@ -238,7 +238,7 @@ string Players::getMPCSpam() {
 								params["title"] = Util::getFileName(filename).substr(0, Util::getFileName(filename).size() - 4);
 								params["size"] = Util::formatBytes(File::getSize(filename));
 							}
-							delete test;
+							delete [] test;
 							CoTaskMemFree(pFileName);
 							// alternative to FreeMediaType(mt)
 							// provided by MSDN DirectX 9 help page for FreeMediaType

--- a/windows/RichTextBox.cpp
+++ b/windows/RichTextBox.cpp
@@ -1126,7 +1126,7 @@ void RichTextBox::handleSearchDir() {
 void RichTextBox::handleDeleteFile() {
 	string path = Text::fromT(selectedWord);
 	string msg = STRING_F(DELETE_FILE_CONFIRM, path);
-	if(WinUtil::MessageBoxConfirm(SettingsManager::CONFIRM_FILE_DELETIONS, Text::toT(msg).c_str())) {
+	if(WinUtil::MessageBoxConfirm(SettingsManager::CONFIRM_FILE_DELETIONS, Text::toT(msg))) {
 		MainFrame::getMainFrame()->addThreadedTask([=] { File::deleteFileEx(path, 3); });
 	}
 

--- a/windows/SystemFrame.cpp
+++ b/windows/SystemFrame.cpp
@@ -440,7 +440,7 @@ LRESULT SystemFrame::onOpenFolder(WORD /*wNotifyCode*/, WORD /*wID*/, HWND /*hWn
 LRESULT SystemFrame::onDeleteFile(WORD /*wNotifyCode*/, WORD /*wID*/, HWND /*hWndCtl*/, BOOL& /*bHandled*/) {
 	string path = Text::fromT(selWord);
 	string msg = STRING_F(DELETE_FILE_CONFIRM, path);
-	if(WinUtil::MessageBoxConfirm(SettingsManager::CONFIRM_FILE_DELETIONS, Text::toT(msg).c_str())) {
+	if(WinUtil::MessageBoxConfirm(SettingsManager::CONFIRM_FILE_DELETIONS, Text::toT(msg))) {
 		MainFrame::getMainFrame()->addThreadedTask([=] { 
 			if (File::deleteFileEx(path, 3))
 				ShareManager::getInstance()->removeTempShare(path); 

--- a/windows/WinUtil.cpp
+++ b/windows/WinUtil.cpp
@@ -1470,7 +1470,7 @@ void WinUtil::appendPreviewMenu(OMenu& parent, const string& aTarget) {
 			string application = i->getApplication();
 			string arguments = i->getArguments();
 
-			previewMenu->appendItem(Text::toT((i->getName())).c_str(), [=] {
+			previewMenu->appendItem(Text::toT((i->getName())), [=] {
 				string tempTarget = QueueManager::getInstance()->getTempTarget(aTarget);
 				ParamMap ucParams;				
 	


### PR DESCRIPTION
V808 'su' object of 'basic_string' type was created but was not utilized. adchub.cpp 880
V808 'targets' object of 'vector' type was created but was not utilized. downloadmanager.cpp 73
V808 'hubIpPort' object of 'basic_string' type was created but was not utilized. uploadmanager.cpp 593
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting first argument of the function loadKeyprint. cryptomanager.cpp 490
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting first argument of the function toInt64. magnet.cpp 64
V611 The memory was allocated using 'new T[]' operator but was released using the 'delete' operator. Consider inspecting this code. It's probably better to use 'delete [] test;'. players.cpp 241
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting first argument of the function appendItem. downloadbasehandler.h 135
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting first argument of the function appendItem. downloadbasehandler.h 148
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting first argument of the function createSubMenu. downloadbasehandler.h 182
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting first argument of the function appendItem. downloadbasehandler.h 184
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting first argument of the function appendItem. downloadbasehandler.h 188
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting first argument of the function appendItem. downloadbasehandler.h 203
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting first argument of the function appendItem. downloadbasehandler.h 229
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting second argument of the function MessageBoxConfirm. richtextbox.cpp 1129
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting first argument of the function createSubMenu. mainfrm.cpp 2029
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting first argument of the function appendItem. mainfrm.cpp 2033
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting first argument of the function appendItem. mainfrm.cpp 2036
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting second argument of the function MessageBoxConfirm. systemframe.cpp 443
V811 Decreased performance. Excessive type casting: string -> char * -> string. Consider inspecting first argument of the function appendItem. winutil.cpp 1473